### PR TITLE
Add procedure to create dist

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Essential modification items are as follows:
 
 Run the build script for the Chrome extension:
 ```
+mkdir dist
 npm install && npm run build:ext
 ```
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -75,7 +75,9 @@ Chrome向けのextension用ソースコードも含まれています。
 
 
 ECLRTC-ScreenShareディレクトリに入り、Chrome extension用のビルドスクリプトを実行します。
+
 ```
+mkdir dist
 npm install && npm run build:ext
 ```
 


### PR DESCRIPTION
Without `dist` dir, npm run build:ext fails. 