### PR TITLE
Introduce UnknownAdapter

### DIFF
--- a/src/adapter/unknown.js
+++ b/src/adapter/unknown.js
@@ -14,7 +14,7 @@ class UnknownAdapter {
   /**
    * Start screen share.
    * Just rejects for not supported browser.
-   * @return {Promise<MediaStream>} - Promise resolved with MediaStream instance.
+   * @return {Promise<MediaStream>} - Always returns rejected Promise with error.
    */
   start() {
     const err = new Error('This browser does not support screen share.');

--- a/src/adapter/unknown.js
+++ b/src/adapter/unknown.js
@@ -13,11 +13,7 @@ class UnknownAdapter {
 
   /**
    * Start screen share.
-   * For Chrome, you can specify mediaSource to share via dialog called by Extension.
-   * @param {Object} [params] - Options for getUserMedia constraints.
-   * @param {number} [params.width] - Constraints for width.
-   * @param {number} [params.height] - Constraints for height.
-   * @param {number} [params.frameRate] - Constraints for frameRate.
+   * Just rejects for not supported browser.
    * @return {Promise<MediaStream>} - Promise resolved with MediaStream instance.
    */
   start() {

--- a/src/adapter/unknown.js
+++ b/src/adapter/unknown.js
@@ -1,0 +1,44 @@
+/**
+ * ScreenShare class for unknown(not supported browser).
+ */
+class UnknownAdapter {
+  /**
+   * Create instance.
+   * @param {Logger} logger - Logger instance passed by factory.
+   */
+  constructor(logger) {
+    this._logger = logger;
+    this._logger.log('This browser does not support screen share.');
+  }
+
+  /**
+   * Start screen share.
+   * For Chrome, you can specify mediaSource to share via dialog called by Extension.
+   * @param {Object} [params] - Options for getUserMedia constraints.
+   * @param {number} [params.width] - Constraints for width.
+   * @param {number} [params.height] - Constraints for height.
+   * @param {number} [params.frameRate] - Constraints for frameRate.
+   * @return {Promise<MediaStream>} - Promise resolved with MediaStream instance.
+   */
+  start() {
+    const err = new Error('This browser does not support screen share.');
+    return Promise.reject(err);
+  }
+
+  /**
+   * Stop screen share.
+   */
+  stop() {
+    // nothing to do
+  }
+
+  /**
+   * Returns whether screen sharing is available or NOT.
+   * @return {boolean} - Screen sharing is available or NOT.
+   */
+  isScreenShareAvailable() {
+    return false;
+  }
+}
+
+export default UnknownAdapter;

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ class ScreenShare {
    * Create ScreenShare instance.
    * @param {Object} [options] - Options for ScreenShare.
    * @param {boolean} [options.debug=false] - If true, print logs.
-   * @return {FirefoxAdapter|ChromeAdapter|null} - Adapter instance for each supported browser, or null.
+   * @return {FirefoxAdapter|ChromeAdapter|UnknownAdapter} - Adapter instance for each supported browser, or unknown for not supported.
    */
   static create(options = {debug: false}) {
     const logger = new Logger(options.debug);

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import {
 } from './shared/util';
 import ChromeAdapter from './adapter/chrome';
 import FirefoxAdapter from './adapter/firefox';
+import UnknownAdapter from './adapter/unknown';
 
 /**
  * Factory class for ScreenShare.
@@ -25,8 +26,7 @@ class ScreenShare {
       case 'chrome':
         return new ChromeAdapter(logger);
       default:
-        this._logger.log('This browser does not support screen share.');
-        return null;
+        return new UnknownAdapter(logger);
     }
   }
 }


### PR DESCRIPTION
Currently, if user calls `ScreenShare.create()` on not supported browser(like Safari).
It throws...

```
TypeError: undefined is not an object (evaluating 'this._logger.log')
  create — screenshare-latest.js:137
```

This PR fixes this and returns `UnknowAdapter` instead of `null`.

Thus, we can use `ScreenShare.create().isScreenShareAvailable()` on every browser.